### PR TITLE
tighten up time detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+## 0.0.4
+
+Breaking change:  Times are now only coereced if there is no surrounding text.  
+
+I.e. "It was 04-05-2016" is now considered a String rather than a Time
+

--- a/lib/quack/types/time.rb
+++ b/lib/quack/types/time.rb
@@ -4,13 +4,13 @@ require "quack/type"
 module Quack
   module Types
     class Time < Quack::Type
-      YMD_FORMAT = /
+      YMD_FORMAT = /\A
         (?<year>\d{4})(-|\/)
         (?<month>\d{2})(-|\/)
         (?<day>\d{2})
-      /x
+      \z/x
 
-      ISO_8601 = /
+      ISO_8601 = /\A
         (?<year>\d{4})-
         (?<month>\d{2})-
         (?<day>\d{2})T
@@ -18,7 +18,7 @@ module Quack
         (?<minute>\d{2}):
         (?<second>\d{2})
         (?<offset>Z|(\+|-)(\d{2}):(\d{2}))
-      /x
+      \z/x
 
       UTC = "+00:00"
 
@@ -28,11 +28,11 @@ module Quack
         end
 
         def iso_8601?(value)
-          !!(value.to_s =~ ISO_8601)
+          !!(value.to_s.strip =~ ISO_8601)
         end
 
         def ymd?(value)
-          !!(value.to_s =~ YMD_FORMAT)
+          !!(value.to_s.strip =~ YMD_FORMAT)
         end
 
         def matches?(value)

--- a/lib/quack/version.rb
+++ b/lib/quack/version.rb
@@ -1,3 +1,3 @@
 module Quack
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/quack/guesser_spec.rb
+++ b/spec/quack/guesser_spec.rb
@@ -4,7 +4,7 @@ describe Quack::Guesser do
   describe "given a string integer" do
     let(:value) { "123" }
     let(:subject) { Quack::Guesser.new(value) }
-    
+
     it "should have Integer type" do
       subject.guess.class.must_equal(Quack::Types::Integer)
     end
@@ -79,6 +79,33 @@ describe Quack::Guesser do
 
     it "should have Time type" do
       subject.guess.class.must_equal(Quack::Types::Time)
+    end
+  end
+
+  describe "given a padded ISO 8061 UTC date" do
+    let(:value) { "     2014-03-22T03:00:00Z " }
+    let(:subject) { Quack::Guesser.new(value) }
+
+    it "should have Time type" do
+      subject.guess.class.must_equal(Quack::Types::Time)
+    end
+  end
+
+  describe "given an embedded ISO 8061 UTC date" do
+    let(:value) { "something awesome will happen 2014-03-22T03:00:00Z or thereabouts" }
+    let(:subject) { Quack::Guesser.new(value) }
+
+    it "should have String type" do
+      subject.guess.class.must_equal(Quack::Types::String)
+    end
+  end
+
+  describe "given an embedded simple date" do
+    let(:value) { "something awesome will happen 2014-03-22 or thereabouts" }
+    let(:subject) { Quack::Guesser.new(value) }
+
+    it "should have String type" do
+      subject.guess.class.must_equal(Quack::Types::String)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/DripEmail/drip/issues/3008

Make it so strings with embedded dates do not get coerced to dates.