### PR TITLE
Ruby 2.4

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2016 Derrick Reimer
+Copyright (c) 2014-2017 Derrick Reimer
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ value.class
 value.to_coerced
 #=> 123
 value.to_coerced.class
+#=> Integer
+```
+
+### Integer (Ruby 2.3 and earlier)
+
+```ruby
+value = Quack("123")
+value.class
+#=> Quack::Types::Integer
+value.to_coerced
+#=> 123
+value.to_coerced.class
 #=> Fixnum
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.libs.push "lib"
-  t.libs.push "spec"
+  t.libs = ["spec"]
   t.test_files = FileList["spec/**/*_spec.rb"]
   t.verbose = true
 end

--- a/lib/quack/types/integer.rb
+++ b/lib/quack/types/integer.rb
@@ -7,7 +7,8 @@ module Quack
 
       class << self
         def built_in_types
-          [Fixnum, Bignum]
+          @@built_in_types ||=
+            [1.class, 10000000000000000000.class].uniq
         end
 
         def matches?(value)

--- a/lib/quack/types/integer.rb
+++ b/lib/quack/types/integer.rb
@@ -8,7 +8,7 @@ module Quack
       class << self
         def built_in_types
           @@built_in_types ||=
-            [1.class, 10000000000000000000.class].uniq
+            ObjectSpace.each_object(Integer.singleton_class).to_a
         end
 
         def matches?(value)

--- a/quack.gemspec
+++ b/quack.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
 end

--- a/spec/quack/types/integer_spec.rb
+++ b/spec/quack/types/integer_spec.rb
@@ -6,11 +6,11 @@ describe Quack::Types::Integer do
       Quack::Types::Integer.matches?("123").must_equal(true)
     end
 
-    it "should be true for Fixnum" do
+    it "should be true for Integer" do
       Quack::Types::Integer.matches?(123).must_equal(true)
     end
 
-    it "should be true for Bignum" do
+    it "should be true for large Integer" do
       num = 232305722798259244150093798251441
       Quack::Types::Integer.matches?(num).must_equal(true)
     end
@@ -25,21 +25,21 @@ describe Quack::Types::Integer do
   end
 
   describe "#to_coerced" do
-    it "should return original value if its a Fixnum" do
+    it "should return original value if its a Integer" do
       type = Quack::Types::Integer.new(2)
       type.to_coerced.must_equal(2)
     end
 
-    it "should return original value if its a Bignum" do
+    it "should return original value if its a large Integer" do
       num = 232305722798259244150093798251441
       type = Quack::Types::Integer.new(num)
       type.to_coerced.must_equal(num)
     end
 
-    it "should cast integer strings to Fixnum" do
+    it "should cast integer strings to Integer" do
       type = Quack::Types::Integer.new("123")
       type.to_coerced.must_equal(123)
-      type.to_coerced.class.must_equal(Fixnum)
+      type.to_coerced.class.must_equal(1.class)
     end
   end
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,5 +1,4 @@
 $:.unshift File.expand_path('../../lib', __FILE__)
 
 require "quack"
-require "minitest/spec"
 require "minitest/autorun"


### PR DESCRIPTION
Upgrade quack gem to work with currently supported ruby versions: 2.2, 2.3, 2.4

It was a bit tricky getting this to work without any deprecation warnings and without doing any monkeying around with internal types...